### PR TITLE
101 umi correction merging bug

### DIFF
--- a/nextflow.nf
+++ b/nextflow.nf
@@ -77,7 +77,7 @@ process MakeCube {
 
     script:
     """
-    deli cube from-counters merged_counters.pkl ${params.decode_run} --out-path ${prefix}_cube.csv
+    deli cube from-counter merged_counters.pkl ${params.decode_run} --out-path ${prefix}_cube.csv
     """
 }
 
@@ -96,7 +96,7 @@ process MergeStats {
     script:
     """
     deli decode statistics merge *_decode_statistics.json --counter-file merged_counters.pkl --out-path ${prefix}_decode_statistics.json
-    deli decode report generate ${params.decode_run} ${prefix}_decode_statistics.json --out-dir ${prefix}_decode_report.html
+    deli decode report generate ${params.decode_run} ${prefix}_decode_statistics.json --out-path ${prefix}_decode_report.html
     """
 }
 

--- a/src/deli/decode/__init__.py
+++ b/src/deli/decode/__init__.py
@@ -3,7 +3,7 @@
 from .decoder import DecodedBarcode, DecodeStatistics, FailedDecode
 from .degen import DELibraryPoolCounter, DELibraryPoolIdCounter, DELibraryPoolIdUmiCounter
 from .report import build_decoding_report
-from .runner import DecodingRunner, DecodingSettings
+from .runner import DecodingRunner, DecodingRunnerResults, DecodingSettings
 
 
 __all__ = [
@@ -16,4 +16,5 @@ __all__ = [
     "DELibraryPoolIdCounter",
     "DELibraryPoolIdUmiCounter",
     "build_decoding_report",
+    "DecodingRunnerResults",
 ]

--- a/src/deli/decode/degen.py
+++ b/src/deli/decode/degen.py
@@ -396,6 +396,10 @@ class DELibraryPoolCounter(abc.ABC):
 
     del_counter: dict
 
+    def __len__(self):
+        """Get total number of unique DELs in the counter"""
+        return sum([len(barcodes) for barcodes in self.del_counter.values()])
+
     @abc.abstractmethod
     def __add__(self, other):
         """
@@ -523,10 +527,6 @@ class DELibraryPoolIdUmiCounter(DELibraryPoolCounter):
             {k: defaultdict(DELIdUmiCounter, v) for k, v in state["del_counter"].items()},
         )
 
-    def __len__(self):
-        """Get total number of unique DELs in the counter"""
-        return sum([len(barcodes) for barcodes in self.del_counter.values()])
-
     def __add__(self, other):
         """
         Add two DELibraryPoolIdUmiCounter objects together
@@ -569,9 +569,9 @@ class DELibraryPoolIdUmiCounter(DELibraryPoolCounter):
                 if (_length_self == 0) and (_length_other == 0):
                     continue
                 _cached_lib = (
-                    self.del_counter[library_id].popitem()[0].library
+                    iter(self.del_counter[library_id].keys()).__next__().library
                     if _length_self > 0
-                    else other.del_counter[library_id].popitem()[0].library
+                    else iter(other.del_counter[library_id].keys()).__next__().library
                 )
                 for barcode in (
                     self.del_counter[library_id].keys() | other.del_counter[library_id].keys()
@@ -585,7 +585,7 @@ class DELibraryPoolIdUmiCounter(DELibraryPoolCounter):
                     ]
                     new_counter.del_counter[library_id][barcode] = (
                         self.del_counter[library_id][barcode]
-                        + self.del_counter[library_id][barcode]
+                        + other.del_counter[library_id][barcode]
                     )
 
             return new_counter

--- a/src/deli/decode/degen.py
+++ b/src/deli/decode/degen.py
@@ -9,6 +9,7 @@ from typing import Literal
 
 from Levenshtein import distance as levenshtein_distance
 
+from ..dels import DELEnumerator
 from .decoder import DecodedBarcode
 from .umi import UMI
 
@@ -449,14 +450,20 @@ class DELibraryPoolCounter(abc.ABC):
         tuple[str, str, str]
             the row tuple for a given DEL ID
         """
-        for decoded_barcode_id, counter in self.del_counter.items():
-            yield (
-                decoded_barcode_id,
-                str(counter.get_raw_count()),
-                str(counter.get_degen_count()),
-            )
+        for lib_counter in self.del_counter.values():
+            for decoded_barcode_id, counter in lib_counter.items():
+                yield (
+                    decoded_barcode_id,
+                    str(counter.get_raw_count()),
+                    str(counter.get_degen_count()),
+                )
 
-    def to_csv(self, path: str | os.PathLike, file_format: Literal["csv", "tsv"] = "csv") -> None:
+    def to_csv(
+        self,
+        path: str | os.PathLike,
+        file_format: Literal["csv", "tsv"] = "csv",
+        enumerator: list[DELEnumerator] | None = None,
+    ) -> None:
         """
         Write the Pool Counter to a human-readable separated value file
 
@@ -471,6 +478,8 @@ class DELibraryPoolCounter(abc.ABC):
             path to save file to
         file_format: Literal["csv", "tsv"] = "csv"
             which file format to write to
+        enumerator: list[DELEnumerator] | None, default = None
+            a list of DELEnumerator objects to use for enumerating SMILES during output
         """
         delimiter: str
         if file_format == "tsv":

--- a/src/deli/decode/report.py
+++ b/src/deli/decode/report.py
@@ -168,8 +168,7 @@ def _generate_lib_degen_pie_chart(decode_stats: DecodeStatistics):
 def build_decoding_report(
     selection: Selection,
     stats: DecodeStatistics,
-    out_dir: str | os.PathLike = "./",
-    prefix: str | None = None,
+    out_path: str | os.PathLike,
 ):
     """
     Generates a deli decoding html report from report stats
@@ -186,23 +185,9 @@ def build_decoding_report(
         the selection to build the report for
     stats: DecodeStatistics
         the decode run statistics to build the report for
-    out_dir: Union[str, os.PathLike], default = "./"
-        the directory to save the report to
-        defaults to the current working directory
-    prefix: Union[str, None], default = None
-        the prefix to use for the report file name
-        if None, will use the selection_id
-        if provided, will be used as the prefix for the report file name
+    out_path: Union[str, os.PathLike]
+        the path to save the report to
     """
-    if prefix is None:
-        _prefix = selection.selection_id
-    else:
-        _prefix = prefix
-    os.makedirs(out_dir, exist_ok=True)
-    _filename = f"{_prefix}_decode_statistics.json"
-
-    out_path = os.path.join(out_dir, _filename)
-
     _seq_count_data: dict = {
         **{
             "Total": (

--- a/src/deli/decode/runner.py
+++ b/src/deli/decode/runner.py
@@ -601,7 +601,7 @@ class DecodingRunner:
         os.makedirs(out_dir, exist_ok=True)
         _filename = f"{_prefix}_cube.csv"
         _out_path = os.path.join(out_dir, _filename)
-        self.degen.to_file(_out_path)
+        self.degen.to_csv(_out_path, file_format="csv")
         self.logger.debug(
             f"Wrote decode results for selection " f"{self.selection.selection_id} to {_out_path}"
         )

--- a/src/deli/decode/runner.py
+++ b/src/deli/decode/runner.py
@@ -13,7 +13,7 @@ import yaml
 from tqdm import tqdm
 
 from deli._logging import get_dummy_logger, get_logger
-from deli.dels import DELibrary, DELibraryPool, SequencedSelection
+from deli.dels import DELibrary, DELibraryPool, Selection, SequencedSelection
 
 from .decoder import DecodedBarcode, DecodeStatistics, DELPoolDecoder
 from .degen import DELibraryPoolCounter, DELibraryPoolIdCounter, DELibraryPoolIdUmiCounter
@@ -169,6 +169,232 @@ class DecodingSettings(dict):
                 raise RuntimeError(f"Failed to load decode settings from {path}") from e
 
 
+class DecodingRunnerResults:
+    """Hold the results of a decoding run"""
+
+    def __init__(
+        self,
+        selection: Selection,
+        decode_statistics: DecodeStatistics | None = None,
+        degen: DELibraryPoolCounter | None = None,
+    ):
+        """
+        Initialize the decoding runner results
+
+        Parameters
+        ----------
+        selection: Selection
+            the selection that was decoded
+        decode_statistics: DecodeStatistics | None, default = None
+            the decode statistics for the run
+        degen: DELibraryPoolCounter | None, default = None
+            the degeneration counter for the run
+        """
+        self.selection = selection
+        self.decode_statistics = decode_statistics
+        self.degen = degen
+
+    def write_decode_report(self, out_path: str | os.PathLike):
+        """
+        Write the decoding statistics for this run
+
+        Parameters
+        ----------
+        out_path: str | PathLike
+            path to save decoding statistics to
+        """
+        if self.decode_statistics is not None:
+            if os.path.dirname(out_path) != "":
+                os.makedirs(os.path.dirname(out_path), exist_ok=True)
+            build_decoding_report(
+                selection=self.selection, stats=self.decode_statistics, out_path=out_path
+            )
+        else:
+            raise RuntimeError("Cannot write decode report, no decode statistics found")
+
+    def write_decode_statistics(self, out_path: str | os.PathLike):
+        """
+        Write the decoding statistics for this run
+
+        Parameters
+        ----------
+        out_path: str | PathLike
+            path to save decoding statistics to
+        """
+        if self.decode_statistics is not None:
+            if os.path.dirname(out_path) != "":
+                os.makedirs(os.path.dirname(out_path), exist_ok=True)
+            self.decode_statistics.to_file(out_path)
+        else:
+            raise RuntimeError("Cannot write decode statistics, no decode statistics found")
+
+    def write_cube(
+        self,
+        out_path: str | os.PathLike,
+        include_library_id_col: bool = False,
+        include_bb_id_cols: bool = False,
+        include_bb_smi_cols: bool = False,
+        include_raw_count_col: bool = True,
+        enumerate_smiles: bool = False,
+        file_format: Literal["csv", "tsv"] = "csv",
+    ) -> None:
+        """
+        Write the resulting DEL counts to a human-readable separated value file
+
+        Will write a unique result file for each selection in the experiment.
+
+        Each row will be a unique DEL ID with at least 2 and at most 11 columns.
+        If including BB columns, the max cycle number is the number of columns included,
+        with DELs from libraries with smaller cycle counts set to 'null'.
+        Below are the columns in order of appearance:
+        - DEL_ID
+        - LIBRARY_ID (if `include_library_id_col` is True)
+        - <For [#] of bb cycles in the library>
+            - BB[#]_ID (if `include_bb_id_cols` is True)
+            - BB[#]_SMILES (if `include_bb_smi_cols` is True)
+        - ENUMERATED_SMILES
+        - RAW_COUNT (if `include_raw_count_col` is True)
+        - UMI_CORRECTED_COUNT (same as raw count if not using UMI degen)
+
+        If `enumerate_smiles` is True, the enumerated SMILES will be generated on the
+        fly using the reaction data provided in the library files.
+        If this is missing, the SMILES will be set to 'null'.
+        Also note that on the fly enumeration will have a dramatic impact on runtime.
+        For large DELs, it can be far more efficient to enumerate the SMILES
+        once, save in a database, and then map the enumerated SMILES to the DEL ID
+        in the CSV file with a join.
+
+        Notes
+        -----
+        If running decoding in parallel, a call to `to_csv` should be made after
+        all decoding is complete and the counters have been merged.
+        Merging raw csv files will result is data loss and incorrect counts,
+        especially if UMI degen is used.
+
+        Parameters
+        ----------
+        out_path: str | PathLike
+            path to save results to
+            will create the directory if it does not exist
+        file_format: Literal["csv", "tsv"] = "csv"
+            which file format to write to
+            either "csv" or "tsv"
+        include_library_id_col: bool, default = False
+            include the library ID in the output
+        include_bb_id_cols: bool, default = False
+            include the building block IDs in the output
+        include_bb_smi_cols: bool, default = False
+            include the building block SMILES in the output
+        include_raw_count_col: bool, default = True
+            include the raw count in the output
+        enumerate_smiles: bool, default = False
+            include the enumerated SMILES in the output
+            Note: this will have a dramatic impact on runtime
+
+        Warnings
+        --------
+        UserWarning
+            - raised when enumeration is requested but some libraries are
+            missing enumerators
+            - raised when building block smiles are requested but some libraries
+            are missing this info
+        """
+        delimiter: str
+        if file_format == "tsv":
+            delimiter = "\t"
+        elif file_format == "csv":
+            delimiter = ","
+        else:
+            raise ValueError(f"file format '{file_format}' not recognized")
+
+        # check for enumeration
+        if enumerate_smiles:
+            if not self.selection.library_pool.all_libs_have_enumerators():
+                _libraries_missing_enumerators = [
+                    lib.library_id
+                    for lib in self.selection.library_pool.libraries
+                    if lib.enumerator is None
+                ]
+                warnings.warn(
+                    f"Some libraries are missing enumerators: "
+                    f"{_libraries_missing_enumerators}. "
+                    "On the fly enumeration will be skipped for these libraries. "
+                    "Please check the library files to ensure they have the "
+                    "correct reaction data.",
+                    stacklevel=2,
+                )
+
+        # check for building block smiles
+        if include_bb_smi_cols:
+            if not self.selection.library_pool.all_libs_have_building_block_smiles():
+                _libraries_missing_bb_smi = [
+                    lib.library_id
+                    for lib in self.selection.library_pool.libraries
+                    if not lib.building_blocks_have_smi()
+                ]
+                warnings.warn(
+                    f"Some libraries are missing building block smiles: "
+                    f"{_libraries_missing_bb_smi}. "
+                    "Building block smiles will be skipped for these libraries. "
+                    "Please check the building block files to ensure they have "
+                    "the correct smiles.",
+                    stacklevel=2,
+                )
+
+        # get max_cycle_size
+        _max_cycle_size = (
+            self.selection.library_pool.max_cycle_size()
+            if (include_bb_id_cols or include_bb_smi_cols)
+            else 0
+        )
+
+        # set header
+        _header = "DEL_ID"
+        if include_library_id_col:
+            _header += f"{delimiter}LIBRARY_ID"
+        for i in range(_max_cycle_size):
+            if include_bb_id_cols:
+                _header += f"{delimiter}BB{i+1}_ID"
+            if include_bb_smi_cols:
+                _header += f"{delimiter}BB{i+1}_SMILES"
+        if enumerate_smiles:
+            _header += f"{delimiter}SMILES"
+        if include_raw_count_col:
+            _header += f"{delimiter}RAW_COUNT"
+        _header += f"{delimiter}UMI_CORRECTED_COUNT\n"
+
+        if self.degen is not None:
+            if os.path.dirname(out_path) != "":
+                os.makedirs(os.path.dirname(out_path), exist_ok=True)
+
+            # write the file
+            with open(out_path, "w") as f:
+                # write header
+                f.write(_header)
+                for library_count_set in self.degen.del_counter.values():
+                    for decode_barcode, counts in library_count_set.items():
+                        _row = f"{decode_barcode.id}"
+                        if include_library_id_col:
+                            _row += f"{delimiter}{decode_barcode.library.library_id}"
+                        for _, bb in zip_longest(
+                            range(_max_cycle_size), decode_barcode.building_blocks
+                        ):
+                            if include_bb_id_cols:
+                                _row += f"{delimiter}" f"{bb.bb_id if bb is not None else 'null'}"
+                            if include_bb_smi_cols:
+                                _row += (
+                                    f"{delimiter}"
+                                    f"{bb.smiles if (bb is not None and bb.smiles) else 'null'}"
+                                )
+                        if enumerate_smiles:
+                            _row += f"{delimiter}{decode_barcode.get_smiles(default='null')}"
+                        if include_raw_count_col:
+                            _row += f"{delimiter}{counts.get_raw_count()}"
+                        _row += f"{delimiter}{counts.get_degen_count()}\n"
+        else:
+            raise RuntimeError("Cannot write cube, no degeneration counter found")
+
+
 class DecodingRunner:
     """
     Main runner for decoding selections
@@ -262,7 +488,9 @@ class DecodingRunner:
         else:
             self.degen = DELibraryPoolIdCounter()
 
-    def run(self, save_failed_to: str | os.PathLike | None = None, use_tqdm: bool = False):
+    def run(
+        self, save_failed_to: str | os.PathLike | None = None, use_tqdm: bool = False
+    ) -> DecodingRunnerResults:
         """
         Run the decoder
 
@@ -277,6 +505,11 @@ class DecodingRunner:
             turn on a tqdm tracking bar
             only recommended if running a single
             runner
+
+        Returns
+        -------
+        DecodingRunnerResults
+            the results of the decode run
         """
         self.logger.info(f"Running decoding for selection: {self.selection.selection_id}")
 
@@ -285,7 +518,7 @@ class DecodingRunner:
             f"Saving failed reads to {save_failed_to} for selection {self.selection.selection_id}"
         )
         _failed_file = (
-            os.path.join(save_failed_to, f"{self.selection.selection_id}_decode_failed.csv")
+            os.path.join(save_failed_to, f"{self.selection.selection_id}_decode_failed.tsv")
             if save_failed_to is not None
             else None
         )
@@ -293,8 +526,9 @@ class DecodingRunner:
 
         # write header to the failed reads CSV
         if fail_csv_file is not None:
-            fail_csv_file.write("read_id,sequence,quality,reason_failed,lib_call\n")
+            fail_csv_file.write("read_id\tsequence\tquality\treason_failed\tlib_call\n")
 
+        _decodes = []
         # look through all sequences in the selection
         for i, seq_record in enumerate(
             tqdm(
@@ -307,7 +541,7 @@ class DecodingRunner:
 
             # decode the read
             decoded_barcode = self.decoder.decode_read(seq_record)
-
+            _decodes.append(decoded_barcode)
             # skip failed reads
             if isinstance(decoded_barcode, DecodedBarcode):
                 self.decoder.decode_statistics.num_seqs_decoded_per_lib[
@@ -318,12 +552,14 @@ class DecodingRunner:
                     self.decoder.decode_statistics.num_seqs_degen_per_lib[
                         decoded_barcode.library.library_id
                     ] += 1
+                else:
+                    print("HERE")
             elif fail_csv_file is not None:
                 # if we are saving failed reads, save the read
                 fail_csv_file.write(
-                    f"{seq_record.id},"
-                    f"{seq_record.sequence},"
-                    f"{seq_record.qualities},"
+                    f"{seq_record.id}\t"
+                    f"{seq_record.sequence}\t"
+                    f"{seq_record.qualities}\t"
                     f"{decoded_barcode.__class__.__name__}\n"
                 )
 
@@ -340,6 +576,11 @@ class DecodingRunner:
             )
 
         self.logger.info(f"Completed decoding for selection: {self.selection.selection_id}")
+        return DecodingRunnerResults(
+            selection=self.selection,
+            decode_statistics=self.decoder.decode_statistics,
+            degen=self.degen,
+        )
 
     def to_file(self, out_path: str | PathLike):
         """
@@ -510,232 +751,4 @@ class DecodingRunner:
             decode_settings=_decode_setting_obj,
             disable_logging=disable_logging,
             debug=debug,
-        )
-
-    def write_decode_report(self, out_dir: str | os.PathLike, prefix: str | None = None):
-        """
-        Write the decoding report for this run
-
-        Notes
-        -----
-        Will write a unique report for each selection in the experiment.
-        All files will be `html` and be named "{?prefix}_<selection_id>_decode_report.html"
-
-
-        Parameters
-        ----------
-        out_dir: str | PathLike
-            path to directory to save results to
-            will create the directory if it does not exist
-        prefix: str, default = None
-            prefix for output files,
-            if None will default to the selection ID
-        """
-        if prefix is None:
-            _prefix = self.selection.selection_id
-        else:
-            _prefix = prefix
-
-        os.makedirs(out_dir, exist_ok=True)
-        _filename = f"{_prefix}_decode_report.html"
-        _out_path = os.path.join(out_dir, _filename)
-        build_decoding_report(self.selection, self.decoder.decode_statistics, _out_path)
-        self.logger.debug(
-            f"Wrote decode report for selection " f"{self.selection.selection_id} to {_out_path}"
-        )
-
-    def write_decode_statistics(self, out_dir: str | os.PathLike, prefix: str | None = None):
-        """
-        Write the decoding statistics for this run
-
-        Notes
-        -----
-        Will write a unique statistics file for each selection in the experiment.
-        All files will be `json` and be named "{?prefix}_<selection_id>_decode_statistics.json"
-
-        Parameters
-        ----------
-        out_dir: str | PathLike
-            path to directory to save results to
-            will create the directory if it does not exist
-        prefix: str, default = None
-            prefix for output files,
-            if None will default to the selection ID
-        """
-        if prefix is None:
-            _prefix = self.selection.selection_id
-        else:
-            _prefix = prefix
-
-        os.makedirs(out_dir, exist_ok=True)
-        _filename = f"{_prefix}_decode_statistics.json"
-        _out_path = os.path.join(out_dir, _filename)
-        self.decoder.decode_statistics.to_file(_out_path)
-        self.logger.debug(
-            f"Wrote decode statistics for selection "
-            f"{self.selection.selection_id} to {_out_path}"
-        )
-
-    def write_cube(
-        self,
-        out_path: str | os.PathLike,
-        include_library_id_col: bool = False,
-        include_bb_id_cols: bool = False,
-        include_bb_smi_cols: bool = False,
-        include_raw_count_col: bool = True,
-        enumerate_smiles: bool = False,
-        file_format: Literal["csv", "tsv"] = "csv",
-    ) -> None:
-        """
-        Write the resulting DEL counts to a human-readable separated value file
-
-        Will write a unique result file for each selection in the experiment.
-
-        Each row will be a unique DEL ID with at least 2 and at most 11 columns.
-        If including BB columns, the max cycle number is the number of columns included,
-        with DELs from libraries with smaller cycle counts set to 'null'.
-        Below are the columns in order of appearance:
-        - DEL_ID
-        - LIBRARY_ID (if `include_library_id_col` is True)
-        - <For [#] of bb cycles in the library>
-            - BB[#]_ID (if `include_bb_id_cols` is True)
-            - BB[#]_SMILES (if `include_bb_smi_cols` is True)
-        - ENUMERATED_SMILES
-        - RAW_COUNT (if `include_raw_count_col` is True)
-        - UMI_CORRECTED_COUNT (same as raw count if not using UMI degen)
-
-        If `enumerate_smiles` is True, the enumerated SMILES will be generated on the
-        fly using the reaction data provided in the library files.
-        If this is missing, the SMILES will be set to 'null'.
-        Also note that on the fly enumeration will have a dramatic impact on runtime.
-        For large DELs, it can be far more efficient to enumerate the SMILES
-        once, save in a database, and then map the enumerated SMILES to the DEL ID
-        in the CSV file with a join.
-
-        Notes
-        -----
-        If running decoding in parallel, a call to `to_csv` should be made after
-        all decoding is complete and the counters have been merged.
-        Merging raw csv files will result is data loss and incorrect counts,
-        especially if UMI degen is used.
-
-        Parameters
-        ----------
-        out_path: str | PathLike
-            path to save results to
-            will create the directory if it does not exist
-        file_format: Literal["csv", "tsv"] = "csv"
-            which file format to write to
-            either "csv" or "tsv"
-        include_library_id_col: bool, default = False
-            include the library ID in the output
-        include_bb_id_cols: bool, default = False
-            include the building block IDs in the output
-        include_bb_smi_cols: bool, default = False
-            include the building block SMILES in the output
-        include_raw_count_col: bool, default = True
-            include the raw count in the output
-        enumerate_smiles: bool, default = False
-            include the enumerated SMILES in the output
-            Note: this will have a dramatic impact on runtime
-
-        Warnings
-        --------
-        UserWarning
-            - raised when enumeration is requested but some libraries are
-            missing enumerators
-            - raised when building block smiles are requested but some libraries
-            are missing this info
-        """
-        delimiter: str
-        if file_format == "tsv":
-            delimiter = "\t"
-        elif file_format == "csv":
-            delimiter = ","
-        else:
-            raise ValueError(f"file format '{file_format}' not recognized")
-
-        # check for enumeration
-        if enumerate_smiles:
-            if not self.selection.library_pool.all_libs_have_enumerators():
-                _libraries_missing_enumerators = [
-                    lib.library_id
-                    for lib in self.selection.library_pool.libraries
-                    if lib.enumerator is None
-                ]
-                warnings.warn(
-                    f"Some libraries are missing enumerators: "
-                    f"{_libraries_missing_enumerators}. "
-                    "On the fly enumeration will be skipped for these libraries. "
-                    "Please check the library files to ensure they have the "
-                    "correct reaction data.",
-                    stacklevel=2,
-                )
-
-        # check for building block smiles
-        if include_bb_smi_cols:
-            if not self.selection.library_pool.all_libs_have_building_block_smiles():
-                _libraries_missing_bb_smi = [
-                    lib.library_id
-                    for lib in self.selection.library_pool.libraries
-                    if not lib.building_blocks_have_smi()
-                ]
-                warnings.warn(
-                    f"Some libraries are missing building block smiles: "
-                    f"{_libraries_missing_bb_smi}. "
-                    "Building block smiles will be skipped for these libraries. "
-                    "Please check the building block files to ensure they have "
-                    "the correct smiles.",
-                    stacklevel=2,
-                )
-
-        # get max_cycle_size
-        _max_cycle_size = (
-            self.selection.library_pool.max_cycle_size()
-            if (include_bb_id_cols or include_bb_smi_cols)
-            else 0
-        )
-
-        # set header
-        _header = "DEL_ID"
-        if include_library_id_col:
-            _header += f"{delimiter}LIBRARY_ID"
-        for i in range(_max_cycle_size):
-            if include_bb_id_cols:
-                _header += f"{delimiter}BB{i+1}_ID"
-            if include_bb_smi_cols:
-                _header += f"{delimiter}BB{i+1}_SMILES"
-        if enumerate_smiles:
-            _header += f"{delimiter}SMILES"
-        if include_raw_count_col:
-            _header += f"{delimiter}RAW_COUNT"
-        _header += f"{delimiter}UMI_CORRECTED_COUNT\n"
-
-        # write the file
-        with open(out_path, "w") as f:
-            # write header
-            f.write(_header)
-            for library_count_set in self.degen.del_counter.values():
-                for decode_barcode, counts in library_count_set.items():
-                    _row = f"{decode_barcode.id}"
-                    if include_library_id_col:
-                        _row += f"{delimiter}{decode_barcode.library.library_id}"
-                    for _, bb in zip_longest(
-                        range(_max_cycle_size), decode_barcode.building_blocks
-                    ):
-                        if include_bb_id_cols:
-                            _row += f"{delimiter}" f"{bb.bb_id if bb is not None else 'null'}"
-                        if include_bb_smi_cols:
-                            _row += (
-                                f"{delimiter}"
-                                f"{bb.smiles if (bb is not None and bb.smiles) else 'null'}"
-                            )
-                    if enumerate_smiles:
-                        _row += f"{delimiter}{decode_barcode.get_smiles(default='null')}"
-                    if include_raw_count_col:
-                        _row += f"{delimiter}{counts.get_raw_count()}"
-                    _row += f"{delimiter}{counts.get_degen_count()}\n"
-
-        self.logger.debug(
-            f"Wrote decode results for selection " f"{self.selection.selection_id} to {out_path}"
         )

--- a/src/deli/decode/runner.py
+++ b/src/deli/decode/runner.py
@@ -528,7 +528,6 @@ class DecodingRunner:
         if fail_csv_file is not None:
             fail_csv_file.write("read_id\tsequence\tquality\treason_failed\tlib_call\n")
 
-        _decodes = []
         # look through all sequences in the selection
         for i, seq_record in enumerate(
             tqdm(
@@ -541,7 +540,6 @@ class DecodingRunner:
 
             # decode the read
             decoded_barcode = self.decoder.decode_read(seq_record)
-            _decodes.append(decoded_barcode)
             # skip failed reads
             if isinstance(decoded_barcode, DecodedBarcode):
                 self.decoder.decode_statistics.num_seqs_decoded_per_lib[
@@ -552,8 +550,6 @@ class DecodingRunner:
                     self.decoder.decode_statistics.num_seqs_degen_per_lib[
                         decoded_barcode.library.library_id
                     ] += 1
-                else:
-                    print("HERE")
             elif fail_csv_file is not None:
                 # if we are saving failed reads, save the read
                 fail_csv_file.write(

--- a/src/deli/dels/__init__.py
+++ b/src/deli/dels/__init__.py
@@ -2,6 +2,7 @@
 
 from .barcode import BarcodeSchema, BuildingBlockBarcodeSection
 from .building_block import BaseBuildingBlock, BuildingBlock, BuildingBlockSet, MaskedBuildingBlock
+from .compound import LowMemDELCompound
 from .enumerator import DELEnumerator
 from .library import DELibrary, DELibraryPool
 from .selection import SectionCondition, Selection, SequencedSelection
@@ -22,4 +23,5 @@ __all__ = [
     "SectionCondition",
     "SequencedSelection",
     "Selection",
+    "LowMemDELCompound",
 ]

--- a/src/deli/dels/compound.py
+++ b/src/deli/dels/compound.py
@@ -41,6 +41,16 @@ class LowMemDELCompound:
         self.building_block_smiles = building_block_smis
         self.enumerated_smi = enumerated_smi
 
+    def __eq__(self, other):
+        """Check if two LowMemDELCompound objects are equal."""
+        if not isinstance(other, LowMemDELCompound):
+            return False
+        return self.compound_id == other.compound_id
+
+    def __hash__(self):
+        """Return the hash of the object."""
+        return hash(self.compound_id)
+
     def __repr__(self):
         """Return a string representation of the object."""
         return self.compound_id

--- a/src/deli/dels/compound.py
+++ b/src/deli/dels/compound.py
@@ -1,0 +1,46 @@
+"""for classes relating to DEL compounds"""
+
+
+class LowMemDELCompound:
+    """
+    Low memory DEL compound class
+
+    Rather than pointing to objects, this class stores
+    info about a compound as strings, based on the ids
+    """
+
+    def __init__(
+        self,
+        compound_id: str,
+        library_id: str,
+        building_blocks_ids: list[str],
+        building_block_smis: list[str | None] | None = None,
+        enumerated_smi: str | None = None,
+    ):
+        """
+        Initialize the LowMemDELCompound object.
+
+        Parameters
+        ----------
+        compound_id: str
+            The ID of the compound.
+        library_id: str
+            The ID of the library.
+        building_blocks_ids: list[str]
+            The IDs of the building blocks.
+        building_block_smis: list[str | None] | None, default None
+            The SMILES representations of the building blocks.
+            must be same length as building_blocks_ids if not None
+        enumerated_smi: str | None, default None
+            The enumerated SMILES representation of the compound.
+            If unknown, set to None.
+        """
+        self.compound_id = compound_id
+        self.library_id = library_id
+        self.building_blocks_ids = building_blocks_ids
+        self.building_block_smiles = building_block_smis
+        self.enumerated_smi = enumerated_smi
+
+    def __repr__(self):
+        """Return a string representation of the object."""
+        return self.compound_id

--- a/src/deli/dels/library.py
+++ b/src/deli/dels/library.py
@@ -271,6 +271,17 @@ class DELibrary(DeliDataLoadable):
                 f"cannot enumerate library {self.library_id} without reaction information"
             )
 
+    def building_blocks_have_smi(self) -> bool:
+        """
+        Check if any building block sets in the library are missing SMILES
+
+        Returns
+        -------
+        bool
+            True if all building block sets have SMILES, False otherwise
+        """
+        return any([bb_set.has_smiles for bb_set in self.bb_sets])
+
 
 class DELibraryPool:
     """base class for any class that holds a group of DEL libraries"""
@@ -341,3 +352,34 @@ class DELibraryPool:
             return self._library_map[library_id]
         except KeyError as e:
             raise KeyError(KeyError(f"cannot find library with id '{library_id}' in pool")) from e
+
+    def all_libs_have_enumerators(self) -> bool:
+        """
+        Check if all libraries in the pool have valid DEL enumerators
+
+        Returns
+        -------
+        bool
+        """
+        return all([lib.enumerator is not None for lib in self.libraries])
+
+    def all_libs_have_building_block_smiles(self) -> bool:
+        """
+        Check if all libraries in the pool have building block SMILES
+
+        Returns
+        -------
+        bool
+        """
+        return all([lib.building_blocks_have_smi() for lib in self.libraries])
+
+    def max_cycle_size(self) -> int:
+        """
+        Get the maximum cycle size of all libraries in the pool
+
+        Returns
+        -------
+        int
+            The maximum cycle size
+        """
+        return max([lib.num_cycles for lib in self.libraries])

--- a/tests/test_enumerator.py
+++ b/tests/test_enumerator.py
@@ -59,6 +59,6 @@ def test_enumerator_enumerate_bb(del_enumerator):
     compound = del_enumerator.get_enumerated_compound_from_bb_ids(bb_map)
 
     assert (
-        compound.smi == "*NC(=O)[C@H](Cc1ccc(I)cc1)N([H])C(=O)c1ccc2c"
-        "(c1)N=C(c1ccc3cccnc3c1)N2Cc1ccc(-n2cccn2)cc1"
+        compound.smi == "[H]N(C(=O)c1ccc2c(c1)N=C(c1ccc3cccnc3c1)N2Cc1ccc"
+        "(-n2cccn2)cc1)[C@@H](Cc1ccc(I)cc1)C([15NH2])=O"
     )


### PR DESCRIPTION
Fixed the bug from #101 where the parallelization/merging of degen count data caused miscounting

Now, the degen counters are saved as pickles, which can be merged together. To prevent excess data use it also makes sure all libraries share the same refs to avoid duplicating objects 

Also added the `DecodingRunnerResult` class to better manager decoding results