### PR TITLE
Fix analysis warnings

### DIFF
--- a/src/deli/analysis/analysis_parse.py
+++ b/src/deli/analysis/analysis_parse.py
@@ -150,7 +150,7 @@ def main():
             print("Report generation completed!")
             today_date = datetime.now().strftime("%Y%m%d")
             cube.data.to_csv(os.path.join(output_dir_base, f"cube_data_{today_date}.csv"), index=False)
-            print(f"Cube data saved to {os.path.join(output_dir, 'cube_data.csv')}")
+            print(f"Cube data saved to {os.path.join(output_dir_base, 'cube_data_{today_date}.csv')}")
 
 if __name__ == '__main__':
     main()

--- a/src/deli/analysis/analysis_parse.py
+++ b/src/deli/analysis/analysis_parse.py
@@ -120,7 +120,7 @@ def main():
             )
         if 'trisynthon_overlap' in flags and flags.get('trisynthon_overlap', False):
             trisynthon_dir = create_output_dir(os.path.join(output_dir, "trisynthon"))
-            cube.trisynthon_overlap(output_dir=trisynthon_dir)
+            cube.trisynthon_overlap(output_dir=trisynthon_dir, threshold=int(flags.get('trisynthon_threshold', 20)))
         if 'disynthon_overlap' in flags and flags.get('disynthon_overlap', False):
             disynthon_dir = create_output_dir(os.path.join(output_dir, "disynthon"))
             cube.disynthon_overlap(output_dir=disynthon_dir, disynthon_data=disynthon_data, disynth_exp_dict=disynth_exp_dict, threshold=int(flags.get('disynthon_threshold', 20)))

--- a/src/deli/analysis/analysis_parse.py
+++ b/src/deli/analysis/analysis_parse.py
@@ -120,7 +120,7 @@ def main():
             )
         if 'trisynthon_overlap' in flags and flags.get('trisynthon_overlap', False):
             trisynthon_dir = create_output_dir(os.path.join(output_dir, "trisynthon"))
-            cube.trisynthon_overlap(output_dir=trisynthon_dir, threshold=int(flags.get('trisynthon_threshold', 20)))
+            cube.trisynthon_overlap(output_dir=trisynthon_dir, threshold=int(flags.get('trisynthon_threshold', 0)))
         if 'disynthon_overlap' in flags and flags.get('disynthon_overlap', False):
             disynthon_dir = create_output_dir(os.path.join(output_dir, "disynthon"))
             cube.disynthon_overlap(output_dir=disynthon_dir, disynthon_data=disynthon_data, disynth_exp_dict=disynth_exp_dict, threshold=int(flags.get('disynthon_threshold', 20)))
@@ -150,7 +150,7 @@ def main():
             print("Report generation completed!")
             today_date = datetime.now().strftime("%Y%m%d")
             cube.data.to_csv(os.path.join(output_dir_base, f"cube_data_{today_date}.csv"), index=False)
-            print(f"Cube data saved to {os.path.join(output_dir_base, 'cube_data_{today_date}.csv')}")
+            print(f"Cube data saved to {os.path.join(output_dir_base, f"cube_data_{today_date}.csv")}")
 
 if __name__ == '__main__':
     main()

--- a/src/deli/analysis/cube_class.py
+++ b/src/deli/analysis/cube_class.py
@@ -444,7 +444,7 @@ class DELi_Cube:
 
         for count_cols in exp_dict.values():
             for col in count_cols:
-                df[col].fillna(0, inplace=True)
+                df[col] = df[col].fillna(0)
 
         self.data = df
         return df, exp_dict
@@ -619,10 +619,10 @@ class DELi_Cube:
 
         for exp_name, index_range in self.indexes.items():
             for column in index_range:
-                spotfire_df.rename(columns={column: f'{exp_name}_{column}'}, inplace=True)
+                spotfire_df = spotfire_df.rename(columns={column: f'{exp_name}_{column}'})
             avg_col_name = f'{exp_name}_avg'
             if avg_col_name not in spotfire_df.columns:
-                spotfire_df[avg_col_name] = df[index_range].mean(axis=1).round(2)
+                spotfire_df.loc[:, avg_col_name] = df[index_range].mean(axis=1).round(2)
 
         return spotfire_df
 


### PR DESCRIPTION
Minor changes to analysis code.
- Resolved pandas and RDKit warnings
- Added trisynthon/disynthon overlap errors when reads below threshold for easier debugging
- Added top_n_compounds errors for the same thing (like March 6th DEL run)

There are definitely still a lot more user-friendly guardrails to set up for DELi analysis in the future