### PR TITLE
Fixing errors encountered when decoding with nextflow

### DIFF
--- a/nextflow/decode.py
+++ b/nextflow/decode.py
@@ -3,7 +3,7 @@
 import argparse
 import os
 
-from deli.decode import DecodingRunner
+from deli.decode.runner import DecodingRunner
 
 
 parser = argparse.ArgumentParser()

--- a/nextflow/merge_umi.py
+++ b/nextflow/merge_umi.py
@@ -7,8 +7,9 @@ import os
 from collections import defaultdict
 from itertools import zip_longest
 
-from deli.decode import DecodeStatistics, build_decoding_report
-from deli.dels import Selection
+from deli.decode.decoder import DecodeStatistics
+from deli.decode.report import build_decoding_report
+from deli.dels.selection import SequencedSelection
 
 
 parser = argparse.ArgumentParser()
@@ -50,7 +51,7 @@ for statistic_file in statistic_files[1:]:
     merged_stats += loaded_statistics
 
 # build the cube file
-selection = Selection.from_yaml(args.decode_file)
+selection = SequencedSelection.from_yaml(args.decode_file)
 _max_cycle_size = selection.library_collection.max_cycle_size()
 
 # build cube file header

--- a/nextflow/merge_umi.py
+++ b/nextflow/merge_umi.py
@@ -94,6 +94,7 @@ with open(f"./{selection.selection_id}_cube.csv", "w") as f:
                     _row += f",{_smi}"
             _row += f",{compound_data['raw_count']}"
             _row += f",{degen_count}\n"
+            f.write(_row)
 
 # reset the umi counts in the stats object
 merged_stats.num_seqs_degen_per_lib = updated_num_seqs_degen_per_lib

--- a/nextflow/nextflow.nf
+++ b/nextflow/nextflow.nf
@@ -80,7 +80,7 @@ process Decode {
 
     script:
     """
-    python ${workflow.projectDir}/decode.py --decode_file ${params.decode_run} --fastq_file ${fastq_file} ${params.debug ? '--debug ' : ''}${params.save_failed ? '--save-failed ' : ''}
+    python ${workflow.projectDir}/decode.py --decode_file ${params.decode_run} --fastq_file ${fastq_file} ${params.debug ? '--debug ' : ''}${params.save_failed ? '--save_failed ' : ''}
     """
 }
 


### PR DESCRIPTION
1) Fixed imports for the nextflow/decode.py, merge_umi.py
2) Updated argument name used in nextflow for the decoding script
3) Used sequenced selection in the merging script (to allow compounds with duplicate ids)
4) Write the cube file in merging script.