### PR TITLE
Fix/nextflow script adjustments

### DIFF
--- a/nextflow/nextflow.nf
+++ b/nextflow/nextflow.nf
@@ -285,7 +285,7 @@ workflow {
         .splitText()
         .map { it.trim() }
         .map { file(it) }
-        .splitFastq(by: params.chunk_size)
+        .splitFastq(by: params.chunk_size, file: true)
 
     decoded = DecodeChunk(fastq_chunks, selection_file_path, prefix_ch, Channel.value(deli_args))
 
@@ -323,7 +323,7 @@ workflow {
 
     SummarizeDecodeRun(
         collected_counts.merged_counts,
-        merged_stats.decode_stats,
+        merged_stats.merged_stats,
         prefix_ch
     )
 }

--- a/nextflow/nextflow.nf
+++ b/nextflow/nextflow.nf
@@ -86,7 +86,7 @@ process DecodeChunk {
      * Run deli decode run on a chunk of FASTQ
      * Outputs one TSV file per chunk (no split-by-lib)
      */
-    tag "${fastq_chunk.simplename}"
+    tag "${fastq_chunk.simpleName}"
 
     input:
     path fastq_chunk
@@ -95,8 +95,8 @@ process DecodeChunk {
     val deli_args
 
     output:
-    path "${prefix}_${fastq_chunk.simplename}_decoded.tsv", emit: decoded_tsv
-    path "${prefix}_${fastq_chunk.simplename}_decode_statistics.json", emit: decode_stats
+    path "${prefix}_${fastq_chunk.simpleName}_decoded.tsv", emit: decoded_tsv
+    path "${prefix}_${fastq_chunk.simpleName}_decode_statistics.json", emit: decode_stats
     path "deli.log", emit: deli_log
     """
     mkdir -p decoded_output
@@ -105,7 +105,7 @@ process DecodeChunk {
         "${selection_file}" \
         "${fastq_chunk}" \
         --out-dir ./ \
-        --prefix "${prefix}_${fastq_chunk.simplename}" \
+        --prefix "${prefix}_${fastq_chunk.simpleName}" \
         --skip-report
     """
 }
@@ -214,6 +214,7 @@ process SummarizeDecodeRun {
     path merged_counts
     path decode_stats
     val prefix
+    val deli_args
 
     output:
     path "${prefix}_final_stats.json", emit: final_stats
@@ -235,6 +236,7 @@ process WriteDecodeReport {
     input:
     path final_stats
     val prefix
+    val deli_args
 
     output:
     path "${prefix}_decode_report.html", emit: report
@@ -304,7 +306,8 @@ workflow {
 
     WriteDecodeReport(
         merged_stats.merged_stats,
-        prefix_ch
+        prefix_ch,
+        Channel.value(deli_args)
     )
 
     count_chunks = collected_decodes.ndjson
@@ -324,6 +327,7 @@ workflow {
     SummarizeDecodeRun(
         collected_counts.merged_counts,
         merged_stats.merged_stats,
-        prefix_ch
+        prefix_ch,
+        Channel.value(deli_args)
     )
 }

--- a/nextflow/nextflow.nf
+++ b/nextflow/nextflow.nf
@@ -106,8 +106,7 @@ process DecodeChunk {
         "${fastq_chunk}" \
         --out-dir ./ \
         --prefix "${prefix}_${fastq_chunk.simplename}" \
-        --skip-report \
-        --exclude-score
+        --skip-report
     """
 }
 

--- a/nextflow/nextflow.nf
+++ b/nextflow/nextflow.nf
@@ -159,21 +159,22 @@ process CountChunk {
      * Count compounds from a chunk of the collected NDJSON file
      * Input file contains up to 500,000 NDJSON lines
      */
-    tag "${ndjson_chunk.simplename}"
+    tag "${ndjson_chunk.simpleName}"
 
     input:
-    path ("*.ndjson", arity: '1..*')
+    path ndjson_chunk
     val prefix
     val deli_args
 
     output:
-    path "${ndjson_chunk.simplename}_counted.parquet", emit: counted
+    path "${ndjson_chunk.simpleName}_counted.parquet", emit: counted
 
     script:
+    def chunk_name = ndjson_chunk.simpleName
     """
     deli ${deli_args} decode count \
         "${ndjson_chunk}" \
-        --out-loc "${ndjson_chunk.simplename}_counted.parquet" \
+        --out-loc "${chunk_name}_counted.parquet" \
         --output-format parquet \
         --cluster-umis \
         --keep-raw-count \
@@ -314,7 +315,7 @@ workflow {
     )
 
     count_chunks = collected_decodes.ndjson
-        .splitText(by: 500_000)
+        .splitText(by: 500_000, file: true)
 
     counts = CountChunk(
         count_chunks,

--- a/nextflow/nextflow.nf
+++ b/nextflow/nextflow.nf
@@ -235,6 +235,7 @@ process WriteDecodeReport {
 
     input:
     path final_stats
+    path selection_file
     val prefix
     val deli_args
 
@@ -245,6 +246,7 @@ process WriteDecodeReport {
     """
     deli ${deli_args} decode report \
         "${final_stats}" \
+        --selection-file "${selection_file}" \
         --out-loc "${prefix}_decode_report.html"
     """
 }
@@ -306,6 +308,7 @@ workflow {
 
     WriteDecodeReport(
         merged_stats.merged_stats,
+        selection_file_path,
         prefix_ch,
         Channel.value(deli_args)
     )

--- a/nextflow/nextflow.nf
+++ b/nextflow/nextflow.nf
@@ -69,15 +69,15 @@ process ExtractSequenceFiles {
     # Write selection_id
     selection_id = config.get('selection_id', 'unknown')
     with open('selection_id.txt', 'w') as f:
-        f.write(selection_id + '\n')
+        f.write(selection_id + '\\n')
 
     # Write sequence files
     sequence_files = config.get('sequence_files', [])
     with open('files.txt', 'w') as f:
         if isinstance(sequence_files, list):
-            f.write('\n'.join(sequence_files) + '\n')
+            f.write('\\n'.join(sequence_files) + '\\n')
         else:
-            f.write(sequence_files + '\n')
+            f.write(sequence_files + '\\n')
     """
 }
 

--- a/nextflow/nextflow.nf
+++ b/nextflow/nextflow.nf
@@ -218,7 +218,7 @@ process SummarizeDecodeRun {
     val deli_args
 
     output:
-    path "${prefix}_final_stats.json", emit: final_stats
+    path "${prefix}_decode_summary.json", emit: final_stats
 
     script:
     """


### PR DESCRIPTION
# Fix multiple bugs in DELi Nextflow decoding workflow

This PR fixes several bugs found during initial testing of the Nextflow decoding workflow.

## Fixes

- `simpleName` casing was incorrect (was `simplename`)
- `deli_args` was not being passed as input to `WriteDecodeReport` and `SummarizeDecodeRun` processes
- `selection_file` added as input to `WriteDecodeReport` and passed via `--selection-file` option (depends on CLI fix in fix/cli-decode-report-...)
- `count_chunks` split operator missing `file: true`, causing raw text to be passed instead of file path
- `MergeDecodeStatistics` output emit name corrected to `merged_stats`
- `SummarizeDecodeRun` output filename mismatch
- Newline character handling fix in chunked FASTQ processing