### PR TITLE
Fix nextflow pipeline execution and decode CLI bugs

### DIFF
--- a/nextflow/nextflow.nf
+++ b/nextflow/nextflow.nf
@@ -159,7 +159,7 @@ process CountChunk {
      * Count compounds from a chunk of the collected NDJSON file
      * Input file contains up to 500,000 NDJSON lines
      */
-    tag "${ndjson_chunk.simpleName}"
+    tag "${ndjson_chunk.name}"
 
     input:
     path ndjson_chunk
@@ -167,10 +167,10 @@ process CountChunk {
     val deli_args
 
     output:
-    path "${ndjson_chunk.simpleName}_counted.parquet", emit: counted
+    path "${ndjson_chunk.name}_counted.parquet", emit: counted
 
     script:
-    def chunk_name = ndjson_chunk.simpleName
+    def chunk_name = ndjson_chunk.name
     """
     deli ${deli_args} decode count \
         "${ndjson_chunk}" \

--- a/nextflow/nextflow.nf
+++ b/nextflow/nextflow.nf
@@ -284,11 +284,14 @@ workflow {
     prefix_ch = extract.selection_id
         .splitText()
         .map { it.trim() }
+        .filter { it }
         .map { final_prefix ?: it }
+        .first()
 
     fastq_chunks = extract.files
         .splitText()
         .map { it.trim() }
+        .filter { it }
         .map { file(it) }
         .splitFastq(by: params.chunk_size, file: true)
 

--- a/nextflow/nextflow.nf
+++ b/nextflow/nextflow.nf
@@ -69,15 +69,15 @@ process ExtractSequenceFiles {
     # Write selection_id
     selection_id = config.get('selection_id', 'unknown')
     with open('selection_id.txt', 'w') as f:
-        f.write(selection_id + '\n')
+        f.write(selection_id + '\\n')
 
     # Write sequence files
     sequence_files = config.get('sequence_files', [])
     with open('files.txt', 'w') as f:
         if isinstance(sequence_files, list):
-            f.write('\n'.join(sequence_files) + '\n')
+            f.write('\\n'.join(sequence_files) + '\\n')
         else:
-            f.write(sequence_files + '\n')
+            f.write(sequence_files + '\\n')
     """
 }
 
@@ -86,7 +86,7 @@ process DecodeChunk {
      * Run deli decode run on a chunk of FASTQ
      * Outputs one TSV file per chunk (no split-by-lib)
      */
-    tag "${fastq_chunk.simplename}"
+    tag "${fastq_chunk.simpleName}"
 
     input:
     path fastq_chunk
@@ -95,8 +95,8 @@ process DecodeChunk {
     val deli_args
 
     output:
-    path "${prefix}_${fastq_chunk.simplename}_decoded.tsv", emit: decoded_tsv
-    path "${prefix}_${fastq_chunk.simplename}_decode_statistics.json", emit: decode_stats
+    path "${prefix}_${fastq_chunk.simpleName}_decoded.tsv", emit: decoded_tsv
+    path "${prefix}_${fastq_chunk.simpleName}_decode_statistics.json", emit: decode_stats
     path "deli.log", emit: deli_log
     """
     mkdir -p decoded_output
@@ -105,9 +105,8 @@ process DecodeChunk {
         "${selection_file}" \
         "${fastq_chunk}" \
         --out-dir ./ \
-        --prefix "${prefix}_${fastq_chunk.simplename}" \
-        --skip-report \
-        --exclude-score
+        --prefix "${prefix}_${fastq_chunk.simpleName}" \
+        --skip-report
     """
 }
 
@@ -160,21 +159,22 @@ process CountChunk {
      * Count compounds from a chunk of the collected NDJSON file
      * Input file contains up to 500,000 NDJSON lines
      */
-    tag "${ndjson_chunk.simplename}"
+    tag "${ndjson_chunk.simpleName}"
 
     input:
-    path ("*.ndjson", arity: '1..*')
+    path ndjson_chunk
     val prefix
     val deli_args
 
     output:
-    path "${ndjson_chunk.simplename}_counted.parquet", emit: counted
+    path "${ndjson_chunk.simpleName}_counted.parquet", emit: counted
 
     script:
+    def chunk_name = ndjson_chunk.simpleName
     """
     deli ${deli_args} decode count \
         "${ndjson_chunk}" \
-        --out-loc "${ndjson_chunk.simplename}_counted.parquet" \
+        --out-loc "${chunk_name}_counted.parquet" \
         --output-format parquet \
         --cluster-umis \
         --keep-raw-count \
@@ -215,9 +215,10 @@ process SummarizeDecodeRun {
     path merged_counts
     path decode_stats
     val prefix
+    val deli_args
 
     output:
-    path "${prefix}_final_stats.json", emit: final_stats
+    path "${prefix}_decode_summary.json", emit: final_stats
 
     script:
     """
@@ -235,7 +236,9 @@ process WriteDecodeReport {
 
     input:
     path final_stats
+    path selection_file
     val prefix
+    val deli_args
 
     output:
     path "${prefix}_decode_report.html", emit: report
@@ -244,6 +247,7 @@ process WriteDecodeReport {
     """
     deli ${deli_args} decode report \
         "${final_stats}" \
+        --selection-file "${selection_file}" \
         --out-loc "${prefix}_decode_report.html"
     """
 }
@@ -286,7 +290,7 @@ workflow {
         .splitText()
         .map { it.trim() }
         .map { file(it) }
-        .splitFastq(by: params.chunk_size)
+        .splitFastq(by: params.chunk_size, file: true)
 
     decoded = DecodeChunk(fastq_chunks, selection_file_path, prefix_ch, Channel.value(deli_args))
 
@@ -305,11 +309,13 @@ workflow {
 
     WriteDecodeReport(
         merged_stats.merged_stats,
-        prefix_ch
+        selection_file_path,
+        prefix_ch,
+        Channel.value(deli_args)
     )
 
     count_chunks = collected_decodes.ndjson
-        .splitText(by: 500_000)
+        .splitText(by: 500_000, file: true)
 
     counts = CountChunk(
         count_chunks,
@@ -324,7 +330,8 @@ workflow {
 
     SummarizeDecodeRun(
         collected_counts.merged_counts,
-        merged_stats.decode_stats,
-        prefix_ch
+        merged_stats.merged_stats,
+        prefix_ch,
+        Channel.value(deli_args)
     )
 }

--- a/src/deli/cli.py
+++ b/src/deli/cli.py
@@ -763,8 +763,8 @@ def run_decode(
             f"{[tool.compound_id for tool_lib in selection.tool_compounds for tool in tool_lib.compounds]}"
         )
 
-    if not hasattr(selection, "sequence_reader"):
-        if len(sequence_files) == 0:
+    if len(sequence_files) == 0:
+        if not hasattr(selection, "sequence_reader"):
             msg = (
                 f"No sequence files provided and no sequence files found in selection file '{selection_file}'; "
                 "cannot decode sequences without sequence files"
@@ -773,11 +773,11 @@ def run_decode(
             click.echo(msg)
             sys.exit(1)
         else:
-            sequence_reader = get_reader(sequence_files)
-            logger.debug(f"using provided sequence files: {sequence_reader.sequence_files}")
+            sequence_reader = selection.sequence_reader
+            logger.debug(f"using sequence files from selection file: {sequence_reader.sequence_files}")
     else:
-        sequence_reader = selection.sequence_reader
-        logger.debug(f"using sequence files from selection file: {sequence_reader.sequence_files}")
+        sequence_reader = get_reader(sequence_files)
+        logger.debug(f"using provided sequence files: {sequence_reader.sequence_files}")
 
     # deal with prefix
     if prefix is None or prefix == "":

--- a/src/deli/cli.py
+++ b/src/deli/cli.py
@@ -837,7 +837,7 @@ def run_decode(
         decode_settings = DecodingSettings.from_file(selection_file)
         logger.info(f"loaded decoding settings from selection file: '{selection_file}'")
     except Exception as e:
-        logger.debug(f"failed to load decoding settings from selection file '{selection_file}': {e}")
+        logger.warning(f"failed to load decoding settings from selection file '{selection_file}': {e}")
 
     if decode_settings_file:
         if decode_settings is not None:
@@ -847,6 +847,9 @@ def run_decode(
             )
         decode_settings = DecodingSettings.from_file(decode_settings_file)
         logger.info(f"loaded decoding settings from: '{decode_settings_file}'")
+
+    if decode_settings is None:
+        logger.warning("no decoding settings found; using default settings")
 
     logger.debug(f"loaded decoding settings: {decode_settings}")
 

--- a/src/deli/cli.py
+++ b/src/deli/cli.py
@@ -1067,7 +1067,7 @@ def count_compounds(ctx, collected_decodes, out_loc, cluster_umis, keep_raw_coun
             out_file = open(out_loc, "w")
         else:
             out_file = gzip.open(out_loc, "wt")
-        writer = lambda x: out_file.write("\n".join(["\t".join([str(val) for val in rd.values()]).strip() for rd in x]))
+        writer = lambda x: out_file.write("\n".join(["\t".join([str(val) for val in rd.values()]).strip() for rd in x]) + "\n")
         _header = ["library_id", "bb_ids", "count"]
         if keep_raw_count:
             _header.append("raw_count")
@@ -1142,7 +1142,7 @@ def count_compounds(ctx, collected_decodes, out_loc, cluster_umis, keep_raw_coun
 
 @decode_group.command(name="report")
 @click.argument("decode_stats_file", nargs=-1, type=click.Path(exists=True), required=True)
-@click.argument("selection_file", type=click.Path(exists=True), required=False, default=None)
+@click.option("--selection-file", "-s", type=click.Path(exists=True), required=False, default=None, help="Selection file used to generate the report")
 @click.option("--out-loc", "-o", type=click.Path(), required=False, default="./decode_report.html", help="Output location to save report to")
 @click.pass_context
 @with_deli_quote

--- a/src/deli/decode/decoder.py
+++ b/src/deli/decode/decoder.py
@@ -1353,12 +1353,20 @@ class DecodingSettings:
             try:
                 return cls(**yaml.safe_load(open(path, "r")))
             except Exception as e:
-                raise RuntimeError(f"Failed to load decode settings from {path}") from e
+                raise RuntimeError(
+                    f"Failed to load decode settings from {path} "
+                    f"(no 'decode_settings' key found, tried loading top-level keys): "
+                    f"{type(e).__name__}: {e}"
+                ) from e
         else:
             try:
                 return cls(**_data["decode_settings"])
             except Exception as e:
-                raise RuntimeError(f"Failed to load decode settings from {path}") from e
+                raise RuntimeError(
+                    f"Failed to load decode settings from {path} "
+                    f"(loaded from 'decode_settings' sub-key): "
+                    f"{type(e).__name__}: {e}"
+                ) from e
 
 
 class SelectionDecoder:

--- a/src/deli/decode/decoder.py
+++ b/src/deli/decode/decoder.py
@@ -904,10 +904,14 @@ class DELibraryDecoder(_SequenceDecoder):
             umi_start = called_sec_spans[self._section_before_umi][1] + self._section_dist_before_umi
             umi_stop = umi_start + len(self.library.barcode_schema.umi_section.section_tag)
             umi_call = aligned_sequence.sequence.sequence[umi_start:umi_stop]
+            if not umi_call and len(self.library.barcode_schema.umi_section.section_tag) > 0:
+                return UMIContainsINDEL(sequence=aligned_sequence.sequence, umi_sequence=umi_call)
         elif self._section_after_umi is not None:
             umi_stop = called_sec_spans[self._section_after_umi][0] - self._section_dist_after_umi
             umi_start = umi_stop - len(self.library.barcode_schema.umi_section.section_tag)
             umi_call = aligned_sequence.sequence.sequence[umi_start:umi_stop]
+            if not umi_call and len(self.library.barcode_schema.umi_section.section_tag) > 0:
+                return UMIContainsINDEL(sequence=aligned_sequence.sequence, umi_sequence=umi_call)
         else:
             return FailedDecodeAttempt(aligned_sequence.sequence, "No sections to determine UMI location")
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -473,6 +473,7 @@ def test_decode_generate_report(tmpdir, runner, mock_decode_stats_file, selectio
         generate_report,
         [
             str(mock_decode_stats_file),
+            "--selection-file",
             str(selection_file_path),
             "--out-loc",
             str(output_report),
@@ -493,6 +494,7 @@ def test_decode_generate_report(tmpdir, runner, mock_decode_stats_file, selectio
         generate_report,
         [
             str(mock_decode_stats_file),
+            "--selection-file",
             str(selection_file_path),
             "--out-loc",
             str(output_dir),


### PR DESCRIPTION
## Nextflow (`nextflow/nextflow.nf`)

1. **`simplename` → `simpleName`** — typo broke chunk tagging and output filenames
2. **Escape sequences** — `\n` → `\\n` inside embedded Python heredoc strings
3. **`splitFastq` / `splitText`** — added `file: true`
4. **`prefix_ch` channel exhaustion** — added `.filter { it }.first()` to emit a single reusable value
5. **`CountChunk` input** — changed from glob pattern to single `path ndjson_chunk`; use `.name` (not `.simpleName`) to preserve chunk index in output filename
6. **Args** — `deli_args` and `selection_file` are now passed to `SummarizeDecodeRun` and `WriteDecodeReport`
7. **Wrong output filename** — `_final_stats.json` → `_decode_summary.json`
8. **Removed `--exclude-score`** — flag dropped from `DecodeChunk` call

## CLI (`src/deli/cli.py`)

9. **Sequence file priority** — `deli decode run` now uses CLI-provided files first, selection file as fallback (matches docstring)
10. **Decode settings error visibility** — silent `debug` log → `warning` with exception type and message
11. **TSV trailing newline** — `count` TSV writer was missing `\n` after each batch
12. **`decode report` arg conflict** — `selection_file` positional → `--selection-file` option (conflicted with variadic `decode_stats_file`)

## Decoder (`src/deli/decode/decoder.py`)

13. **Empty UMI not caught** — return `UMIContainsINDEL` when UMI extraction yields `""` but a UMI is expected
14. **Decode settings error message** — include exception type + message to make parse failures debuggable
